### PR TITLE
Update mdx-components.tsx

### DIFF
--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -6,10 +6,7 @@ import {
 } from "@codesandbox/sandpack-react";
 
 export function CodeBlock({ children }: { children: React.ReactElement }) {
-  const codeArray = children.props.children.split("\n");
-  codeArray.pop();
-  const code = codeArray.join("\n");
-
+  const code = children.props.children.trim();
   const extension = children.props.className.split("-")[1];
 
   return (


### PR DESCRIPTION
Related to https://github.com/codesandbox/sandpack/issues/465

Hey, I was investigating a bit about this problem, and it seems that CodeMirror is miscalculation the length of the document. This made to imagine that the `array.pop` might be called multiple times (in every React render) and rid of the array content.  

Anyway, try to avoid using methods, like `pop`, that change the original value in the root of React components, (if I'm right) this might be the cause of the bug. 