### PR TITLE
fix: tool card height

### DIFF
--- a/src/components/tool-card.tsx
+++ b/src/components/tool-card.tsx
@@ -34,7 +34,7 @@ export default function ToolCard({ tool }: { tool: ITool }) {
   return (
     <motion.article
       {...animations}
-      className="rounded-lg bg-zinc-100 p-4 dark:bg-white/10"
+      className="flex h-full flex-col rounded-lg bg-zinc-100 p-4 dark:bg-white/10"
       style={{
         position: isPresent ? "static" : "absolute",
       }}
@@ -56,7 +56,7 @@ export default function ToolCard({ tool }: { tool: ITool }) {
         <h3 className="shine font-semibold">{name}</h3>
       </header>
 
-      <div className="mt-6 rounded-md bg-white p-4 text-center dark:bg-zinc-800">
+      <div className="mt-6 grow rounded-md bg-white p-4 text-center dark:bg-zinc-800">
         <div className="flex items-center justify-center gap-1">
           {[1, 2, 3, 4, 5].map((rate) => {
             return <Rating key={rate} rate={rate} rating={rating} />;


### PR DESCRIPTION
Tools sayfasindaki her row'daki card'in boylari ayni olsa daha güzel olabilir bence.

Before
<img width="1676" alt="image" src="https://github.com/ademilter/homepage/assets/38289027/f77e03f0-193f-489c-8eb7-f3b931fc34cf">

After
<img width="1676" alt="Screenshot 2023-07-10 at 16 44 00" src="https://github.com/ademilter/homepage/assets/38289027/d5134842-5bb4-4a04-99ed-c7d3b7644f4c">
